### PR TITLE
OCM-22840 | chore: migrate Jira reporter to AccountID and update custom field IDs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/openshift-online/ocm-service-common
 go 1.24.7
 
 require (
-	github.com/andygrunwald/go-jira v1.16.0
+	github.com/andygrunwald/go-jira v1.17.0
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/getkin/kin-openapi v0.131.0
 	github.com/getsentry/sentry-go v0.23.0
@@ -41,7 +41,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
+	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad // indirect
 	github.com/gorilla/css v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030I
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/andygrunwald/go-jira v1.16.0 h1:PU7C7Fkk5L96JvPc6vDVIrd99vdPnYudHu4ju2c2ikQ=
 github.com/andygrunwald/go-jira v1.16.0/go.mod h1:UQH4IBVxIYWbgagc0LF/k9FRs9xjIiQ8hIcC6HfLwFU=
+github.com/andygrunwald/go-jira v1.17.0 h1:bbu5H676l6MaNcV6A7VDIAjIOQVgzNGEhNAwNI/Cjgo=
+github.com/andygrunwald/go-jira v1.17.0/go.mod h1:tiZsPUu9824bwcI2BUXatE4hJbs9rUOif0nv1lkq1hQ=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -57,6 +59,8 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/pkg/client/jira/client.go
+++ b/pkg/client/jira/client.go
@@ -101,11 +101,16 @@ func (c *Client) CreateIssue(fieldsConfig *FieldsConfiguration) (issue *jira.Iss
 		return nil, err
 	}
 
+	reporterAccountID, err := c.GetAccountID(*fieldsConfig.Reporter)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to resolve account ID for reporter %q", *fieldsConfig.Reporter)
+	}
+
 	newIssue := jira.Issue{
 		Fields: &jira.IssueFields{
 			Summary: *fieldsConfig.Summary,
 			Reporter: &jira.User{
-				Name: *fieldsConfig.Reporter,
+				AccountID: reporterAccountID,
 			},
 			Type: jira.IssueType{
 				Name: *fieldsConfig.IssueType,
@@ -181,6 +186,17 @@ func (c *Client) addIssueFields(newIssue jira.Issue, fieldsConfig *FieldsConfigu
 			newIssue.Fields.Unknowns = unknowns
 		}
 	}
+}
+
+func (c *Client) GetAccountID(email string) (string, error) {
+	users, _, err := c.jiraClient.User.Find(email)
+	if err != nil {
+		return "", err
+	}
+	if len(users) == 0 {
+		return "", errors.NotFound.Errorf("no Jira user found for email %q", email)
+	}
+	return users[0].AccountID, nil
 }
 
 func (c *Client) PostAttachment(issueID *string, r io.Reader, name string) (attachment *[]jira.Attachment, err error) {

--- a/pkg/client/jira/unknowns.go
+++ b/pkg/client/jira/unknowns.go
@@ -1,10 +1,10 @@
 package jira
 
-const ProductsCustomField = "customfield_12319040"
-const ClusterIdField = "customfield_12316349"
-const ClusterOrgField = "customfield_12310160"
-const StoryPointsField = "customfield_12310243"
-const WorkTypeField = "customfield_12320040"
+const ProductsCustomField = "customfield_10868"
+const ClusterIdField = "customfield_10852"
+const ClusterOrgField = "customfield_10746"
+const StoryPointsField = "customfield_10028"
+const WorkTypeField = "customfield_10464"
 
 var known = map[string]string{
 	"Products":    ProductsCustomField,

--- a/pkg/client/jira/unknowns_test.go
+++ b/pkg/client/jira/unknowns_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // set const here, to ensure if `ProductsCustomField` changes the test will fail
-const productsCustomField = "customfield_12319040"
+const productsCustomField = "customfield_10868"
 
 var _ = Describe("Unknowns Test", func() {
 	When("Unknown `Products` custom field is passed", func() {


### PR DESCRIPTION
Switch reporter field from username (Name) to AccountID resolved via email lookup to support Jira Cloud API. Update custom field IDs to their new values and bump go-jira to v1.17.0.

Validated locally successfully