### PR TITLE
OCM-22053 | fix: jira search must use V2 go-jira functions

### DIFF
--- a/pkg/client/jira/client.go
+++ b/pkg/client/jira/client.go
@@ -211,15 +211,15 @@ func (c *Client) PostAttachment(issueID *string, r io.Reader, name string) (atta
 }
 
 func (c *Client) GetAllIssues(searchString string, maxResults int) ([]jira.Issue, error) {
-	last := 0
+	nextPageToken := ""
 	issues := make([]jira.Issue, 0)
 	for {
-		opt := &jira.SearchOptions{
-			MaxResults: maxResults, // Max results can go up to 1000
-			StartAt:    last,
+		opt := &jira.SearchOptionsV2{
+			MaxResults:    maxResults, // Max results can go up to 1000
+			NextPageToken: nextPageToken,
 		}
 
-		chunk, resp, err := c.jiraClient.Issue.Search(searchString, opt)
+		chunk, resp, err := c.jiraClient.Issue.SearchV2JQL(searchString, opt)
 		if err != nil {
 			if isRateLimitError(err) {
 				return nil, errors.TooManyRequests.Wrapf(err, "Rate limit exceeded to search issues")
@@ -227,10 +227,9 @@ func (c *Client) GetAllIssues(searchString string, maxResults int) ([]jira.Issue
 			return nil, err
 		}
 
-		total := resp.Total
 		issues = append(issues, chunk...)
-		last = resp.StartAt + len(chunk)
-		if last >= total {
+		nextPageToken = resp.NextPageToken
+		if nextPageToken == "" {
 			return issues, nil
 		}
 	}

--- a/pkg/client/jira/client_test.go
+++ b/pkg/client/jira/client_test.go
@@ -2,11 +2,16 @@ package jira
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/andygrunwald/go-jira"
+	"github.com/openshift-online/ocm-sdk-go/testing"
+
 	// nolint
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega/ghttp"
+
 	// nolint
 	. "github.com/onsi/gomega"
 )
@@ -262,6 +267,103 @@ var _ = Describe("Jira issue", func() {
 			}
 			jiraClient.addIssueFields(newIssue, fieldsConfiguration)
 			Expect(newIssue.Fields.Unknowns).To(BeEmpty())
+		})
+	})
+})
+
+var _ = Describe("Jira Client", func() {
+	var jiraServer *ghttp.Server
+	var jiraClient *Client
+	BeforeEach(func() {
+		jiraServer = testing.MakeTCPServer()
+		jiraServer.SetAllowUnhandledRequests(true)
+		jiraServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+		jiraClient, _ = NewClient("user", "pass", jiraServer.URL())
+	})
+	Describe("GetAllIssues", func() {
+		When("set of issues is empty", func() {
+			BeforeEach(func() {
+				jiraServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyBasicAuth("user", "pass"),
+						ghttp.VerifyRequest(http.MethodGet, "/rest/api/2/search/jql"),
+						testing.RespondWithJSON(http.StatusOK, `{"nextPageToken": "", "isLast": true, "issues": []}`),
+					),
+				)
+			})
+			It("should return an empty set of issues", func() {
+				issues, err := jiraClient.GetAllIssues("", 100)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(issues).To(HaveLen(0))
+			})
+		})
+		When("set of issues is a single page", func() {
+			BeforeEach(func() {
+				jiraServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyBasicAuth("user", "pass"),
+						ghttp.VerifyRequest(http.MethodGet, "/rest/api/2/search/jql"),
+						testing.RespondWithJSON(http.StatusOK, `{"nextPageToken": "", "isLast": true, "issues": [{}, {}]}`),
+					),
+				)
+			})
+			It("should return that single page of issues", func() {
+				issues, err := jiraClient.GetAllIssues("", 100)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(issues).To(HaveLen(2))
+			})
+		})
+		When("set of issues is a multiple pages", func() {
+			BeforeEach(func() {
+				jiraServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyBasicAuth("user", "pass"),
+						ghttp.VerifyRequest(http.MethodGet, "/rest/api/2/search/jql"),
+						testing.RespondWithJSON(http.StatusOK, `{"nextPageToken": "next", "isLast": false, "issues": [{}, {}]}`),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyBasicAuth("user", "pass"),
+						ghttp.VerifyRequest(http.MethodGet, "/rest/api/2/search/jql"),
+						ghttp.VerifyFormKV("nextPageToken", "next"),
+						testing.RespondWithJSON(http.StatusOK, `{"nextPageToken": "", "isLast": true, "issues": [{}, {}, {}]}`),
+					),
+				)
+			})
+			It("should return the concatenated multiple pages of issues", func() {
+				issues, err := jiraClient.GetAllIssues("", 100)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(issues).To(HaveLen(5))
+			})
+		})
+		When("jira client returns a generic error", func() {
+			BeforeEach(func() {
+				jiraServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyBasicAuth("user", "pass"),
+						ghttp.VerifyRequest(http.MethodGet, "/rest/api/2/search/jql"),
+						testing.RespondWithJSON(http.StatusBadRequest, ""),
+					),
+				)
+			})
+			It("should return a generic error", func() {
+				_, err := jiraClient.GetAllIssues("", 100)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+		When("jira client returns a rate limit error", func() {
+			BeforeEach(func() {
+				jiraServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyBasicAuth("user", "pass"),
+						ghttp.VerifyRequest(http.MethodGet, "/rest/api/2/search/jql"),
+						testing.RespondWithJSON(http.StatusTooManyRequests, `{"errorMessages": ["429 Too Many Requests"]}`),
+					),
+				)
+			})
+			It("should return a rate limiting specific error", func() {
+				_, err := jiraClient.GetAllIssues("", 100)
+				Expect(err).To(MatchError(ContainSubstring("Rate limit exceeded to search issues")))
+			})
 		})
 	})
 })


### PR DESCRIPTION
## What

Update the `GetAllIssues` method of the jira client to use the V2 methods of the go-jira client

## Why

atlassian cloud only supports the newer migrated API path for the jql search function, and therefore all requests using the old method will fail against redhat.atlassian.net: switching to the `SearchV2JQL` method will allow callers of this method to function again.